### PR TITLE
[CBS-24] Set default Security Policy to TLSv1.1_2016 and tweak allowed methods

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -101,6 +101,7 @@ resource "aws_ssm_parameter" "client_id" {
   type     = "SecureString"
   value    = okta_app_oauth.default[0].client_id
   key_id   = aws_kms_key.default.id
+  tags     = var.tags
 }
 
 resource "aws_ssm_parameter" "client_secret" {
@@ -110,6 +111,7 @@ resource "aws_ssm_parameter" "client_secret" {
   type     = "SecureString"
   value    = okta_app_oauth.default[0].client_secret
   key_id   = aws_kms_key.default.id
+  tags     = var.tags
 }
 
 resource "aws_ssm_parameter" "okta_org_name" {
@@ -118,6 +120,7 @@ resource "aws_ssm_parameter" "okta_org_name" {
   name     = "${local.ssm_prefix}/okta_org_name"
   type     = "String"
   value    = var.okta_org_name
+  tags     = var.tags
 }
 
 resource "aws_ssm_parameter" "private_key" {
@@ -127,6 +130,7 @@ resource "aws_ssm_parameter" "private_key" {
   type     = "SecureString"
   value    = tls_private_key.default[0].private_key_pem
   key_id   = aws_kms_key.default.id
+  tags     = var.tags
 }
 
 resource "aws_ssm_parameter" "public_key" {
@@ -136,6 +140,7 @@ resource "aws_ssm_parameter" "public_key" {
   type     = "SecureString"
   value    = tls_private_key.default[0].public_key_pem
   key_id   = aws_kms_key.default.id
+  tags     = var.tags
 }
 
 resource "aws_ssm_parameter" "redirect_uri" {
@@ -144,4 +149,5 @@ resource "aws_ssm_parameter" "redirect_uri" {
   name     = "${local.ssm_prefix}/redirect_uri"
   type     = "String"
   value    = local.redirect_uri
+  tags     = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -169,13 +169,13 @@ variable "certificate_arn" {
 
 variable "minimum_protocol_version" {
   type        = string
-  default     = "TLSv1"
+  default     = "TLSv1.1_2016"
   description = "The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections"
 }
 
 variable "allowed_methods" {
   type        = list(string)
-  default     = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+  default     = ["GET", "HEAD", "POST", "PUT"]
   description = "Controls which HTTP methods CloudFront processes and forwards"
 }
 


### PR DESCRIPTION
Some security improvements to the (Default) setup of CloudFront:

* Update the default TLS version to the (suggested) version [`TLSv1.1_2016`](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers).

* Changed the list of default allowed methods

* Added missing tags