### PR TITLE
[IOT-438] Fix DNS change handing of certificate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,10 @@ resource "aws_acm_certificate" "default" {
   domain_name       = local.application_fqdn
   validation_method = "DNS"
   tags              = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "validation" {


### PR DESCRIPTION
As stated by the [documentation](https://www.terraform.io/docs/providers/aws/r/acm_certificate.html):

```
It's recommended to specify create_before_destroy = true in a lifecycle block to replace a certificate which is currently in use (eg, by aws_lb_listener).
```

Since the certificate is used by the CloudFront distribution, implement this