### PR TITLE
Make "wait_for_deployment" configurable and disable by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_cloudfront_distribution" "default" {
   enabled             = var.enabled
   is_ipv6_enabled     = var.ipv6_enabled
   price_class         = var.price_class
-  wait_for_deployment = true
+  wait_for_deployment = var.wait_for_deployment
   tags                = var.tags
 
   origin {

--- a/variables.tf
+++ b/variables.tf
@@ -260,6 +260,12 @@ variable "use_regional_endpoint" {
   description = "Whether to use a regional instead of the global endpoint address"
 }
 
+variable "wait_for_deployment" {
+  type        = bool
+  default     = true
+  description = "Whether to wait for the deployment of the CloudFront Distribution to be complete"
+}
+
 variable "zone_id" {
   type        = string
   description = "ID of the Route53 zone in which to create the subdomain record"


### PR DESCRIPTION
Terraform has the [`wait_for_deployment`](https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#wait_for_deployment) option to specify if it should wait for the entire CloudFront distribution to be deployed.

When CloudFront updates, 2 things happen: The update itself is validated and processe, and then it deploys it globally over all edge locations. This second step can take up to 30 (updates) or 60 (creates) minutes.
The first step is the most important: is the new CloudFront Distribution configuration valid and correct.

For most (if not all) of the Terraform disployments this first step matters (exception could be a resource actually using the CloudFront endpoints). This PR makes this setting configurable and disables the wait by default.

