### PR TITLE
Add "hide_ios" option to the Okta app

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -79,6 +79,7 @@ resource "okta_app_oauth" "default" {
   type                       = "web"
   grant_types                = ["authorization_code", "implicit"]
   groups                     = var.okta_groups
+  hide_ios                   = var.hide_ios
   hide_web                   = var.hide_web
   login_uri                  = "https://${local.login_domain}/"
   redirect_uris              = [local.redirect_uri]

--- a/variables.tf
+++ b/variables.tf
@@ -110,6 +110,12 @@ variable "enabled" {
   description = "Whether the distribution is enabled to accept requests for content"
 }
 
+variable "hide_ios" {
+  type        = bool
+  default     = false
+  description = "Do not display the Okta application icon to users on mobile app"
+}
+
 variable "hide_web" {
   type        = bool
   default     = false


### PR DESCRIPTION
This PR adds the [`hide_ios`](https://www.terraform.io/docs/providers/okta/r/app_oauth.html#hide_ios) setting to the Okta app, this result in the following:

![image](https://user-images.githubusercontent.com/35613489/71008387-cbaf8280-20e8-11ea-9f30-2b774593d61b.png)

This makes it consistent with the other applications we configure in Okta