### PR TITLE
Add dependency to the certificate validation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -143,4 +143,6 @@ resource "aws_cloudfront_distribution" "default" {
       response_page_path    = lookup(custom_error_response.value, "response_page_path", null)
     }
   }
+
+  depends_on = [aws_acm_certificate_validation.default]
 }


### PR DESCRIPTION
Add a dependency between the CloudFront Distribution and the Certificate Validation.

Hitting the 

```Error: error creating CloudFront Distribution: InvalidViewerCertificate: The specified SSL certificate doesn't exist, isn't in us-east-1 region, isn't valid, or doesn't include a valid certificate chain.```

error.

Added this dependency based on the information in the TF issue:
https://github.com/terraform-providers/terraform-provider-aws/issues/8945#issuecomment-582960043