### PR TITLE
Ignore changes in Okta consent_method

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -88,7 +88,7 @@ resource "okta_app_oauth" "default" {
   token_endpoint_auth_method = "client_secret_jwt"
 
   lifecycle {
-    ignore_changes = [users, groups]
+    ignore_changes = [users, groups, consent_method]
   }
 }
 


### PR DESCRIPTION
Suppress the `consent_method` attribute that forces an update every run.

See also: https://github.com/oktadeveloper/terraform-provider-okta/issues/122