### PR TITLE
Change Domain validation method

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,26 +40,19 @@ resource "aws_acm_certificate" "default" {
 }
 
 resource "aws_route53_record" "validation" {
-  for_each = {
-    for dvo in aws_acm_certificate.default[0].domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
-    }
-  }
-
-  name    = each.value.name
-  records = [each.value.record]
-  ttl     = 60
-  type    = each.value.type
+  count   = local.certificate_count
+  name    = aws_acm_certificate.default[count.index].domain_validation_options.*.resource_record_name[0]
+  records = [aws_acm_certificate.default[count.index].domain_validation_options.*.resource_record_value[0]]
+  type    = aws_acm_certificate.default[count.index].domain_validation_options.*.resource_record_type[0]
   zone_id = data.aws_route53_zone.current.zone_id
+  ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "default" {
   count                   = local.certificate_count
   provider                = aws.cloudfront
-  certificate_arn         = aws_acm_certificate.default.0.arn
-  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+  certificate_arn         = aws_acm_certificate.default[count.index].arn
+  validation_record_fqdns = [aws_route53_record.validation[count.index].fqdn]
 }
 
 resource "aws_cloudfront_origin_access_identity" "default" {


### PR DESCRIPTION
Rebuild the domain validation part (again), the current solution with the `for_each` ([introduced here](https://github.com/schubergphilis/terraform-aws-mcaf-cloudfront/pull/43/files) has issues when used in creating infrastructure from scratch, giving the classic error:

```
Error: Invalid for_each argument

  on .terraform/modules/br001oc_cb_opco.tagmanager/main.tf line 43, in resource "aws_route53_record" "validation":
  43:   for_each = {
  44:     for dvo in aws_acm_certificate.default[0].domain_validation_options : dvo.domain_name => {
  45:       name   = dvo.resource_record_name
  46:       record = dvo.resource_record_value
  47:       type   = dvo.resource_record_type
  48:     }
  49:   }

The "for_each" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the for_each depends on.
```

This PR moves it back to using count and assuming there is only one validation option (which is what we also did before we used the for each).

Documentation: https://github.com/hashicorp/terraform-provider-aws/issues/14447