### PR TITLE
Use AWS managed KMS key (1/2)

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -116,7 +116,7 @@ resource "aws_ssm_parameter" "client_id" {
   name     = "${local.ssm_prefix}/client_id"
   type     = "SecureString"
   value    = okta_app_oauth.default[0].client_id
-  key_id   = aws_kms_key.default.id
+  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 
@@ -126,7 +126,7 @@ resource "aws_ssm_parameter" "client_secret" {
   name     = "${local.ssm_prefix}/client_secret"
   type     = "SecureString"
   value    = okta_app_oauth.default[0].client_secret
-  key_id   = aws_kms_key.default.id
+  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 
@@ -145,7 +145,7 @@ resource "aws_ssm_parameter" "private_key" {
   name     = "${local.ssm_prefix}/private_key"
   type     = "SecureString"
   value    = tls_private_key.default[0].private_key_pem
-  key_id   = aws_kms_key.default.id
+  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 
@@ -155,7 +155,7 @@ resource "aws_ssm_parameter" "public_key" {
   name     = "${local.ssm_prefix}/public_key"
   type     = "SecureString"
   value    = tls_private_key.default[0].public_key_pem
-  key_id   = aws_kms_key.default.id
+  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 


### PR DESCRIPTION
Instead of creating a custom KMS for every CloudFront, use the AWS managed key. This simplified the code and saves cost.

This will be a 2 PR (and release) process since it cannot be done in 1 PR for existing deployments:

- Using the AWS managed key by not specifying the KMS key does not work with updates (see: https://github.com/hashicorp/terraform-provider-aws/issues/20150)
- Removing the KMS key in the same PR kills the Terraform run (since the KMS will be destroyed first, after which the update of the SSM parameter fails).

So this is the first PR which updates the SSM values to use the AWS managed key.