### PR TITLE
Use AWS managed KMS key (2/2)

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -8,20 +8,6 @@ locals {
   ssm_prefix         = "/cloudfront-config/${aws_cloudfront_distribution.default.id}"
 }
 
-resource "aws_kms_key" "default" {
-  provider            = aws.cloudfront
-  description         = "KMS key used for encrypting cloudfront SSM parameters"
-  is_enabled          = true
-  enable_key_rotation = false
-  tags                = var.tags
-}
-
-resource "aws_kms_alias" "default" {
-  provider      = aws.cloudfront
-  name          = "alias/cloudfront-ssm-${aws_cloudfront_distribution.default.id}"
-  target_key_id = aws_kms_key.default.key_id
-}
-
 data "aws_iam_policy_document" "authentication" {
   statement {
     actions = [
@@ -38,15 +24,6 @@ data "aws_iam_policy_document" "authentication" {
     ]
     resources = [
       "${module.origin_bucket.arn}${var.origin_path}/*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "kms:Decrypt"
-    ]
-    resources = [
-      aws_kms_key.default.arn
     ]
   }
 
@@ -116,7 +93,6 @@ resource "aws_ssm_parameter" "client_id" {
   name     = "${local.ssm_prefix}/client_id"
   type     = "SecureString"
   value    = okta_app_oauth.default[0].client_id
-  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 
@@ -126,7 +102,6 @@ resource "aws_ssm_parameter" "client_secret" {
   name     = "${local.ssm_prefix}/client_secret"
   type     = "SecureString"
   value    = okta_app_oauth.default[0].client_secret
-  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 
@@ -145,7 +120,6 @@ resource "aws_ssm_parameter" "private_key" {
   name     = "${local.ssm_prefix}/private_key"
   type     = "SecureString"
   value    = tls_private_key.default[0].private_key_pem
-  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 
@@ -155,7 +129,6 @@ resource "aws_ssm_parameter" "public_key" {
   name     = "${local.ssm_prefix}/public_key"
   type     = "SecureString"
   value    = tls_private_key.default[0].public_key_pem
-  key_id   = "alias/aws/ssm"
   tags     = var.tags
 }
 


### PR DESCRIPTION
Instead of creating a custom KMS for every CloudFront, use the AWS managed key. This simplified the code and saves cost.

Part of 2, see also: https://github.com/schubergphilis/terraform-aws-mcaf-cloudfront/pull/78

If an existing CloudFront installation is already deployed there are 2 ways to migrate to the AWS managed key:

**Fully automated:** 
- Update to version `0.8.2` (from previous PR) as an intermediate to correct the SSM parameter values
- Then update to version `0.9.0` (This PR) to remove the old KMS key

**Semi automated**
- Manually remove the current SSM parameters from AWS
- Update to version `0.9.0` (This PR) to remove the old KMS key and recreate the SSM parameters with the correct (AWS managed) key

P.S.
This also fixes the "issue" that the KMS key was ALWAYS created, even if authentication was disabled.
