### PR TITLE
Add Okta application logo support

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -61,6 +61,7 @@ resource "okta_app_oauth" "default" {
   hide_web                   = var.hide_web
   login_uri                  = local.login_uri
   login_mode                 = "SPEC"
+  logo                       = var.application_logo
   redirect_uris              = concat([local.redirect_uri], coalesce(var.additional_redirect_uris, []))
   response_types             = ["token", "id_token", "code"]
   token_endpoint_auth_method = var.okta_spa ? "none" : "client_secret_jwt"

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "allowed_methods" {
 variable "application_logo" {
   type        = string
   default     = null
-  description = "Local path to the application logo image"
+  description = "Relative path to the application logo image"
 }
 
 variable "authentication" {

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "allowed_methods" {
   description = "Controls which HTTP methods CloudFront processes and forwards"
 }
 
+variable "application_logo" {
+  type        = string
+  default     = null
+  description = "Local path to the application logo image"
+}
+
 variable "authentication" {
   type        = bool
   default     = false


### PR DESCRIPTION
Application logo can now be configured using Terraform (https://github.com/okta/terraform-provider-okta/issues/506). This PR implements this feature