### PR TITLE
Add support for new property pkce_required

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
-| <a name="requirement_okta"></a> [okta](#requirement\_okta) | >= 3.16.0 |
+| <a name="requirement_okta"></a> [okta](#requirement\_okta) | >= 3.36.0 |
 
 ## Providers
 
@@ -15,7 +15,7 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
 | <a name="provider_aws.cloudfront"></a> [aws.cloudfront](#provider\_aws.cloudfront) | >= 4.0.0 |
-| <a name="provider_okta"></a> [okta](#provider\_okta) | >= 3.16.0 |
+| <a name="provider_okta"></a> [okta](#provider\_okta) | >= 3.36.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules

--- a/auth.tf
+++ b/auth.tf
@@ -62,6 +62,7 @@ resource "okta_app_oauth" "default" {
   login_uri                  = local.login_uri
   login_mode                 = "SPEC"
   logo                       = var.application_logo
+  pkce_required              = var.okta_spa ? true : false
   redirect_uris              = concat([local.redirect_uri], coalesce(var.additional_redirect_uris, []))
   response_types             = ["token", "id_token", "code"]
   skip_groups                = true

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = ">= 3.16.0"
+      version = ">= 3.36.0"
     }
     tls = {
       source = "hashicorp/tls"


### PR DESCRIPTION
New version of the Okta Terraform provider is released: https://github.com/okta/terraform-provider-okta/blob/master/CHANGELOG.md#3360-september-14-2022

In this version the property `pkce_required ` is added which can give errors in specific situations:

```
Error: failed to update OAuth application: the API returned an error: Api validation failed: App Instance. Causes:
 errorSummary: ''pkce_required'' must be set to true when ''token_endpoint_auth_method'' is ''none''.
```

This PR sets the `pkce_required` as well based on `okta_spa`