### PR TITLE
Optimize Okta Group Assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | [aws_ssm_parameter.private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.public_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.redirect_uri](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [okta_app_group_assignment.default](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_group_assignment) | resource |
+| [okta_app_group_assignments.default](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_group_assignments) | resource |
 | [okta_app_oauth.default](https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_oauth) | resource |
 | [tls_private_key.default](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [aws_iam_policy_document.authentication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
-| <a name="requirement_okta"></a> [okta](#requirement\_okta) | >= 3.36.0 |
+| <a name="requirement_okta"></a> [okta](#requirement\_okta) | >= 3.38.0 |
 
 ## Providers
 
@@ -15,7 +15,7 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
 | <a name="provider_aws.cloudfront"></a> [aws.cloudfront](#provider\_aws.cloudfront) | >= 4.0.0 |
-| <a name="provider_okta"></a> [okta](#provider\_okta) | >= 3.36.0 |
+| <a name="provider_okta"></a> [okta](#provider\_okta) | >= 3.38.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules

--- a/auth.tf
+++ b/auth.tf
@@ -70,14 +70,16 @@ resource "okta_app_oauth" "default" {
   token_endpoint_auth_method = var.okta_spa ? "none" : "client_secret_jwt"
 }
 
-resource "okta_app_group_assignment" "default" {
-  for_each = toset(local.okta_groups)
+resource "okta_app_group_assignments" "default" {
+  count  = var.authentication ? 1 : 0
+  app_id = okta_app_oauth.default[0].id
 
-  app_id   = okta_app_oauth.default[0].id
-  group_id = each.value
+  dynamic "group" {
+    for_each = toset(local.okta_groups)
 
-  lifecycle {
-    ignore_changes = [priority]
+    content {
+      id = group.value
+    }
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = ">= 3.36.0"
+      version = ">= 3.38.0"
     }
     tls = {
       source = "hashicorp/tls"


### PR DESCRIPTION
This PR refactors the Okta Group assignment from multiple resources into a single resource that uses a bulk endpoint.

This improves the amount of calls to Okta and prevents rate limiting issues.

**Documentation and links:**
- https://registry.terraform.io/providers/okta/okta/latest/docs/resources/app_group_assignments
- https://github.com/okta/terraform-provider-okta/issues/396
- https://github.com/okta/terraform-provider-okta/blob/master/CHANGELOG.md#3380-october-28-2022

When testing this a bit already had an implementation where the amount of resources go from 15 to 1