### PR TITLE
Handle "no Okta groups"

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -71,7 +71,7 @@ resource "okta_app_oauth" "default" {
 }
 
 resource "okta_app_group_assignments" "default" {
-  count  = var.authentication ? 1 : 0
+  count  = length(local.okta_groups) > 0 ? 1 : 0
   app_id = okta_app_oauth.default[0].id
 
   dynamic "group" {


### PR DESCRIPTION
If no Okta groups are specified it gives an error:

```Error: Invalid dynamic for_each value
on xxx/auth.tf line 78, in resource "okta_app_group_assignments" "default":
    for_each = toset(local.okta_groups)
local.okta_groups is null
Cannot use a null value in for_each.```