### PR TITLE
Bump S3 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_authentication"></a> [authentication](#module\_authentication) | github.com/schubergphilis/terraform-aws-mcaf-lambda | v0.3.3 |
-| <a name="module_origin_bucket"></a> [origin\_bucket](#module\_origin\_bucket) | github.com/schubergphilis/terraform-aws-mcaf-s3 | v0.6.1 |
+| <a name="module_origin_bucket"></a> [origin\_bucket](#module\_origin\_bucket) | github.com/schubergphilis/terraform-aws-mcaf-s3 | v0.8.0 |
 
 ## Resources
 

--- a/bucket.tf
+++ b/bucket.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "origin_bucket" {
 }
 
 module "origin_bucket" {
-  source                  = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.6.1"
+  source                  = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.8.0"
   name                    = var.name
   block_public_acls       = var.block_public_acls
   block_public_policy     = var.block_public_policy


### PR DESCRIPTION
Bump the S3 module to prevent breaking of new deployments.

See also: https://github.com/schubergphilis/terraform-aws-mcaf-s3/pull/26
