### PR TITLE
Set authentication policy explicitly to null for okta app

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -56,6 +56,7 @@ resource "okta_app_oauth" "default" {
   status                     = "ACTIVE"
   type                       = var.okta_spa ? "browser" : "web"
   consent_method             = var.okta_spa ? "REQUIRED" : "TRUSTED"
+  authentication_policy      = var.authentication_policy
   grant_types                = ["authorization_code", "implicit"]
   hide_ios                   = var.hide_ios
   hide_web                   = var.hide_web

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "authentication" {
   description = "Whether to protect the cloudfront distribution behind an Okta application"
 }
 
+variable "authentication_policy" {
+  type        = string
+  default     = null
+  description = "The authentication policy to assign to the Okta app"
+}
+
 variable "bucket_policy" {
   type        = string
   default     = null


### PR DESCRIPTION
This seem to fix a bug where it gets stuck. By default it is already not set, but setting it explicitly to null should fix the issue.