### PR TITLE
Temporarily pin Okta provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     okta = {
       source  = "okta/okta"
-      version = ">= 4.0.0"
+      version = "3.46.0"
     }
     tls = {
       source = "hashicorp/tls"


### PR DESCRIPTION
This is needed because of below bug
https://github.com/okta/terraform-provider-okta/issues/1552

When this is fixed we should be fine again to pickup the latest provider