### PR TITLE
Restore the skip_ feature

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -65,6 +65,8 @@ resource "okta_app_oauth" "default" {
   pkce_required              = var.okta_spa ? true : false
   redirect_uris              = concat([local.redirect_uri], coalesce(var.additional_redirect_uris, []))
   response_types             = ["token", "id_token", "code"]
+  skip_groups                = true
+  skip_users                 = true
   token_endpoint_auth_method = var.okta_spa ? "none" : "client_secret_jwt"
 }
 


### PR DESCRIPTION
The module is loacked back to version 3. But to make it work correctly, the `skip_` attributes need to be set to prevent the create/remove/create/remove dance between the app and the assignment resources.