### PR TITLE
fix: Add mandatory "create_policy" attribute

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -44,13 +44,14 @@ module "authentication" {
   source  = "schubergphilis/mcaf-lambda/aws"
   version = "~> 1.4.1"
 
-  name     = "${var.name}-authentication"
-  filename = "${path.module}/auth_lambda/artifacts/index.zip"
-  policy   = data.aws_iam_policy_document.authentication.json
-  runtime  = "nodejs22.x"
-  handler  = "index.handler"
-  publish  = true
-  tags     = var.tags
+  name          = "${var.name}-authentication"
+  create_policy = true
+  filename      = "${path.module}/auth_lambda/artifacts/index.zip"
+  policy        = data.aws_iam_policy_document.authentication.json
+  runtime       = "nodejs22.x"
+  handler       = "index.handler"
+  publish       = true
+  tags          = var.tags
 }
 
 resource "okta_app_oauth" "default" {


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Add the `create_policy` to the Authentication Lambda. Needed else deployments fail (found while testing an upgrade from 0.X to 1.0

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
