### PR TITLE
feat!: Add region support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,24 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
-| <a name="requirement_okta"></a> [okta](#requirement\_okta) | >= 4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_okta"></a> [okta](#requirement\_okta) | >= 6.0.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
-| <a name="provider_aws.cloudfront"></a> [aws.cloudfront](#provider\_aws.cloudfront) | >= 5.0.0 |
-| <a name="provider_okta"></a> [okta](#provider\_okta) | >= 4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_okta"></a> [okta](#provider\_okta) | >= 6.0.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_authentication"></a> [authentication](#module\_authentication) | schubergphilis/mcaf-lambda/aws | ~> 1.4.1 |
-| <a name="module_origin_bucket"></a> [origin\_bucket](#module\_origin\_bucket) | schubergphilis/mcaf-s3/aws | ~> 1.5.2 |
+| <a name="module_authentication"></a> [authentication](#module\_authentication) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
+| <a name="module_origin_bucket"></a> [origin\_bucket](#module\_origin\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
 
 ## Resources
 
@@ -112,6 +111,7 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | <a name="input_origin_path"></a> [origin\_path](#input\_origin\_path) | A path that CloudFront uses to request your content from a specific directory | `string` | `""` | no |
 | <a name="input_price_class"></a> [price\_class](#input\_price\_class) | Price class for this distribution | `string` | `"PriceClass_100"` | no |
 | <a name="input_redirect_uri_path"></a> [redirect\_uri\_path](#input\_redirect\_uri\_path) | Path to the login redirect URL | `string` | `"_callback"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | Whether Amazon S3 should restrict public bucket policies for this bucket | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 | <a name="input_use_regional_endpoint"></a> [use\_regional\_endpoint](#input\_use\_regional\_endpoint) | Whether to use a regional instead of the global endpoint address | `bool` | `false` | no |

--- a/auth.tf
+++ b/auth.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "authentication" {
       "ssm:GetParameters"
     ]
     resources = [
-      "arn:aws:ssm:*:*:parameter/${local.ssm_prefix}}/*"
+      "arn:aws:ssm:*:*:parameter/cloudfront-config/*"
     ]
   }
 }

--- a/auth.tf
+++ b/auth.tf
@@ -7,7 +7,6 @@ locals {
   okta_groups        = var.authentication ? var.okta_groups : []
   redirect_uri       = "https://${local.login_domain}/${trimprefix(var.redirect_uri_path, "/")}"
   ssm_prefix         = "/cloudfront-config/${aws_cloudfront_distribution.default.id}"
-
 }
 
 data "aws_iam_policy_document" "authentication" {

--- a/auth.tf
+++ b/auth.tf
@@ -1,11 +1,13 @@
 locals {
   cookie_domain      = var.cookie_domain != null ? var.cookie_domain : local.login_domain
   create_auth_lambda = var.authentication && !var.okta_spa ? ["create"] : []
+  global_region      = "us-east-1"
   login_domain       = aws_route53_record.cloudfront.name
   login_uri          = var.login_uri_path != null ? format("https://%s/%s", local.login_domain, trimprefix(var.login_uri_path, "/")) : "https://${local.login_domain}/"
   okta_groups        = var.authentication ? var.okta_groups : []
   redirect_uri       = "https://${local.login_domain}/${trimprefix(var.redirect_uri_path, "/")}"
   ssm_prefix         = "/cloudfront-config/${aws_cloudfront_distribution.default.id}"
+
 }
 
 data "aws_iam_policy_document" "authentication" {
@@ -32,26 +34,29 @@ data "aws_iam_policy_document" "authentication" {
       "ssm:GetParameters"
     ]
     resources = [
-      "arn:aws:ssm:*:*:parameter/cloudfront-config/${aws_cloudfront_distribution.default.id}/*"
+      "arn:aws:ssm:*:*:parameter/${local.ssm_prefix}}/*"
     ]
   }
 }
 
 module "authentication" {
-  providers = { aws = aws.cloudfront }
-  count     = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
   source  = "schubergphilis/mcaf-lambda/aws"
-  version = "~> 1.4.1"
+  version = "~> 3.0.0"
 
-  name          = "${var.name}-authentication"
-  create_policy = true
-  filename      = "${path.module}/auth_lambda/artifacts/index.zip"
-  policy        = data.aws_iam_policy_document.authentication.json
-  runtime       = "nodejs22.x"
-  handler       = "index.handler"
-  publish       = true
-  tags          = var.tags
+  region   = local.global_region
+  name     = "${var.name}-authentication"
+  filename = "${path.module}/auth_lambda/artifacts/index.zip"
+  runtime  = "nodejs22.x"
+  handler  = "index.handler"
+  publish  = true
+  tags     = var.tags
+
+  execution_role = {
+    create_policy = true
+    policy        = data.aws_iam_policy_document.authentication.json
+  }
 }
 
 resource "okta_app_oauth" "default" {
@@ -91,9 +96,9 @@ resource "tls_private_key" "default" {
 }
 
 resource "aws_ssm_parameter" "client_id" {
-  provider = aws.cloudfront
-  count    = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
+  region = local.global_region
   name   = "${local.ssm_prefix}/client_id"
   key_id = var.kms_key_arn
   type   = "SecureString"
@@ -102,9 +107,9 @@ resource "aws_ssm_parameter" "client_id" {
 }
 
 resource "aws_ssm_parameter" "client_secret" {
-  provider = aws.cloudfront
-  count    = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
+  region = local.global_region
   name   = "${local.ssm_prefix}/client_secret"
   key_id = var.kms_key_arn
   type   = "SecureString"
@@ -114,19 +119,19 @@ resource "aws_ssm_parameter" "client_secret" {
 
 resource "aws_ssm_parameter" "okta_org_name" {
   #checkov:skip=CKV2_AWS_34: "AWS SSM Parameter should be Encrypted"
-  provider = aws.cloudfront
-  count    = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
-  name  = "${local.ssm_prefix}/okta_org_name"
-  type  = "String"
-  value = var.okta_org_name
-  tags  = var.tags
+  region = local.global_region
+  name   = "${local.ssm_prefix}/okta_org_name"
+  type   = "String"
+  value  = var.okta_org_name
+  tags   = var.tags
 }
 
 resource "aws_ssm_parameter" "private_key" {
-  provider = aws.cloudfront
-  count    = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
+  region = local.global_region
   name   = "${local.ssm_prefix}/private_key"
   key_id = var.kms_key_arn
   type   = "SecureString"
@@ -135,9 +140,9 @@ resource "aws_ssm_parameter" "private_key" {
 }
 
 resource "aws_ssm_parameter" "public_key" {
-  provider = aws.cloudfront
-  count    = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
+  region = local.global_region
   name   = "${local.ssm_prefix}/public_key"
   key_id = var.kms_key_arn
   type   = "SecureString"
@@ -147,22 +152,22 @@ resource "aws_ssm_parameter" "public_key" {
 
 resource "aws_ssm_parameter" "redirect_uri" {
   #checkov:skip=CKV2_AWS_34: "AWS SSM Parameter should be Encrypted"
-  provider = aws.cloudfront
-  count    = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
-  name  = "${local.ssm_prefix}/redirect_uri"
-  type  = "String"
-  value = local.redirect_uri
-  tags  = var.tags
+  region = local.global_region
+  name   = "${local.ssm_prefix}/redirect_uri"
+  type   = "String"
+  value  = local.redirect_uri
+  tags   = var.tags
 }
 
 resource "aws_ssm_parameter" "cookie_domain" {
   #checkov:skip=CKV2_AWS_34: "AWS SSM Parameter should be Encrypted"
-  provider = aws.cloudfront
-  count    = length(local.create_auth_lambda)
+  count = length(local.create_auth_lambda)
 
-  name  = "${local.ssm_prefix}/cookie_domain"
-  type  = "String"
-  value = local.cookie_domain
-  tags  = var.tags
+  region = local.global_region
+  name   = "${local.ssm_prefix}/cookie_domain"
+  type   = "String"
+  value  = local.cookie_domain
+  tags   = var.tags
 }

--- a/bucket.tf
+++ b/bucket.tf
@@ -54,8 +54,9 @@ data "aws_iam_policy_document" "origin_bucket" {
 
 module "origin_bucket" {
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 1.5.2"
+  version = "~> 2.0.0"
 
+  region                  = var.region
   name                    = var.name
   block_public_acls       = var.block_public_acls
   block_public_policy     = var.block_public_policy

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -3,17 +3,12 @@ terraform {
 
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      configuration_aliases = [aws.cloudfront]
-      version               = ">= 5.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
     }
     okta = {
       source  = "okta/okta"
-      version = ">= 4.0.0"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 4.1"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,9 @@ locals {
   ) : "${var.name}.s3.amazonaws.com"
 }
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  region = var.region
+}
 
 data "aws_route53_zone" "current" {
   zone_id = var.zone_id
@@ -28,8 +30,9 @@ resource "aws_route53_record" "cloudfront" {
 }
 
 resource "aws_acm_certificate" "default" {
-  count             = local.certificate_count
-  provider          = aws.cloudfront
+  count = local.certificate_count
+
+  region            = local.global_region
   domain_name       = local.application_fqdn
   validation_method = "DNS"
   tags              = var.tags
@@ -58,8 +61,9 @@ resource "aws_route53_record" "validation" {
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  count                   = local.certificate_count
-  provider                = aws.cloudfront
+  count = local.certificate_count
+
+  region                  = local.global_region
   certificate_arn         = aws_acm_certificate.default[count.index].arn
   validation_record_fqdns = [aws_route53_record.validation["create"].fqdn]
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   deployment_arn    = var.deployment_arn != null ? { create : null } : {}
 
   domain_name = var.use_regional_endpoint ? format(
-    "%s.s3-%s.amazonaws.com", var.name, data.aws_region.current.name
+    "%s.s3-%s.amazonaws.com", var.name, data.aws_region.current.region
   ) : "${var.name}.s3.amazonaws.com"
 }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,17 +3,12 @@ terraform {
 
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      configuration_aliases = [aws.cloudfront]
-      version               = ">= 5.0.0"
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
     }
     okta = {
       source  = "okta/okta"
-      version = ">= 4.0.0"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 4.1"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "okta/okta"
       version = ">= 6.0.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.1"
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -294,6 +294,12 @@ variable "redirect_uri_path" {
   description = "Path to the login redirect URL"
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "restrict_public_buckets" {
   type        = bool
   default     = true


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the S3 Cloudfront Terraform module to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for (some) related resources, which improves multi-region compatibility and control. 

Since Cloudfront is a Global "fixed" region this region is now hardcoded inside the module, so no additional configuration is needed.
Additionally, some mcaf modules are updated, and the AWS provider version is updated to the latest major version.

**Region configuration improvements:** 

* Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the vpc and related resources. If omitted, the default provider region is used.
* Updated all resources to accept and use the `region` variable. This ensures consistent resource creation in the specified region.


## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.
