### PR TITLE
fix: Fix logging path

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | <a name="input_ipv6_enabled"></a> [ipv6\_enabled](#input\_ipv6\_enabled) | Whether IPv6 is enabled for the distribution | `bool` | `false` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key used for encryption | `string` | `null` | no |
 | <a name="input_lambda_function_association"></a> [lambda\_function\_association](#input\_lambda\_function\_association) | A config block that triggers a lambda function with specific actions | <pre>list(object({<br/>    event_type   = string<br/>    include_body = bool<br/>    lambda_arn   = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration, logging is disabled by default. | <pre>object({<br/>    target_bucket_arn = string<br/>    target_prefix     = string<br/>    output_format     = optional(string, "parquet")<br/>  })</pre> | `null` | no |
+| <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration, logging is disabled by default. | <pre>object({<br/>    target_bucket = string<br/>    target_prefix = string<br/>    output_format = optional(string, "parquet")<br/>  })</pre> | `null` | no |
 | <a name="input_login_uri_path"></a> [login\_uri\_path](#input\_login\_uri\_path) | Optional path to the login URL | `string` | `null` | no |
 | <a name="input_max_ttl"></a> [max\_ttl](#input\_max\_ttl) | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `86400` | no |
 | <a name="input_min_ttl"></a> [min\_ttl](#input\_min\_ttl) | Minimum amount of time that you want objects to stay in CloudFront caches | `number` | `0` | no |

--- a/logging.tf
+++ b/logging.tf
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_log_delivery_destination" "access_logs" {
   tags          = var.tags
 
   delivery_destination_configuration {
-    destination_resource_arn = "arn:aws:s3:::${var.logging.target_bucket}"
+    destination_resource_arn = "arn:aws:s3:::${var.logging.target_bucket}/${var.logging.target_prefix}"
   }
 }
 
@@ -28,8 +28,4 @@ resource "aws_cloudwatch_log_delivery" "access_logs" {
   delivery_source_name     = aws_cloudwatch_log_delivery_source.access_logs[0].name
   delivery_destination_arn = aws_cloudwatch_log_delivery_destination.access_logs[0].arn
   tags                     = var.tags
-
-  s3_delivery_configuration {
-    suffix_path = var.logging.target_prefix
-  }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Fix the suffix path so the files are stored at the suffix specified.

## :rocket: Motivation

There is a "default" `AWSLogs/{account-id}/CloudFront` path added if not specified. Change the configuration so the actual path is used.
[source](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html#bucket-path-examples)

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
