### PR TITLE
fix(kms)!: `kms_key_arn` is now used to encrypt all relevant resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | <a name="input_authentication"></a> [authentication](#input\_authentication) | Whether to protect the cloudfront distribution behind an Okta application | `bool` | `false` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket | `bool` | `true` | no |
-| <a name="input_bucket_kms_key_arn"></a> [bucket\_kms\_key\_arn](#input\_bucket\_kms\_key\_arn) | The ARN of the KMS key used for S3 origin bucket encryption | `string` | `null` | no |
 | <a name="input_bucket_lifecycle_rule"></a> [bucket\_lifecycle\_rule](#input\_bucket\_lifecycle\_rule) | List of maps containing lifecycle management configuration settings for this bucket | `any` | `[]` | no |
 | <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | The bucket policy to merge with the Cloudfront permissions | `string` | `null` | no |
 | <a name="input_cached_methods"></a> [cached\_methods](#input\_cached\_methods) | Controls whether CloudFront caches the response to requests | `list(string)` | <pre>[<br/>  "GET",<br/>  "HEAD"<br/>]</pre> | no |
@@ -101,9 +100,8 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | <a name="input_hide_web"></a> [hide\_web](#input\_hide\_web) | Do not display the Okta application icon to users | `bool` | `false` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
 | <a name="input_ipv6_enabled"></a> [ipv6\_enabled](#input\_ipv6\_enabled) | Whether IPv6 is enabled for the distribution | `bool` | `false` | no |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key used for SSM SecureString parameter encryption | `string` | `null` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key used for all encryption: SSM SecureString parameters, Lambda CloudWatch log group, and S3 origin bucket | `string` | `null` | no |
 | <a name="input_lambda_function_association"></a> [lambda\_function\_association](#input\_lambda\_function\_association) | A config block that triggers a lambda function with specific actions | <pre>list(object({<br/>    event_type   = string<br/>    include_body = bool<br/>    lambda_arn   = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_lambda_kms_key_arn"></a> [lambda\_kms\_key\_arn](#input\_lambda\_kms\_key\_arn) | The ARN of the KMS key used for the authentication Lambda CloudWatch log group encryption | `string` | `null` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration, logging is disabled by default. | <pre>object({<br/>    target_bucket = string<br/>    target_prefix = string<br/>    output_format = optional(string, "parquet")<br/>  })</pre> | `null` | no |
 | <a name="input_login_uri_path"></a> [login\_uri\_path](#input\_login\_uri\_path) | Optional path to the login URL | `string` | `null` | no |
 | <a name="input_max_ttl"></a> [max\_ttl](#input\_max\_ttl) | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `86400` | no |

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Terraform to create a CloudFront distribution with a S3 origin bucket and Okta a
 As opposed to other MCAF modules, this module does not provide a specific resource, but rather a set of resources that can be used to create a CloudFront distribution with an S3 origin bucket and Okta authentication. It is a very specific use case with a specific set of requirements. 
 
 
-```hcl
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -75,6 +73,7 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | <a name="input_authentication"></a> [authentication](#input\_authentication) | Whether to protect the cloudfront distribution behind an Okta application | `bool` | `false` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket | `bool` | `true` | no |
+| <a name="input_bucket_kms_key_arn"></a> [bucket\_kms\_key\_arn](#input\_bucket\_kms\_key\_arn) | The ARN of the KMS key used for S3 origin bucket encryption | `string` | `null` | no |
 | <a name="input_bucket_lifecycle_rule"></a> [bucket\_lifecycle\_rule](#input\_bucket\_lifecycle\_rule) | List of maps containing lifecycle management configuration settings for this bucket | `any` | `[]` | no |
 | <a name="input_bucket_policy"></a> [bucket\_policy](#input\_bucket\_policy) | The bucket policy to merge with the Cloudfront permissions | `string` | `null` | no |
 | <a name="input_cached_methods"></a> [cached\_methods](#input\_cached\_methods) | Controls whether CloudFront caches the response to requests | `list(string)` | <pre>[<br/>  "GET",<br/>  "HEAD"<br/>]</pre> | no |
@@ -102,8 +101,9 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | <a name="input_hide_web"></a> [hide\_web](#input\_hide\_web) | Do not display the Okta application icon to users | `bool` | `false` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
 | <a name="input_ipv6_enabled"></a> [ipv6\_enabled](#input\_ipv6\_enabled) | Whether IPv6 is enabled for the distribution | `bool` | `false` | no |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key used for encryption | `string` | `null` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key used for SSM SecureString parameter encryption | `string` | `null` | no |
 | <a name="input_lambda_function_association"></a> [lambda\_function\_association](#input\_lambda\_function\_association) | A config block that triggers a lambda function with specific actions | <pre>list(object({<br/>    event_type   = string<br/>    include_body = bool<br/>    lambda_arn   = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_lambda_kms_key_arn"></a> [lambda\_kms\_key\_arn](#input\_lambda\_kms\_key\_arn) | The ARN of the KMS key used for the authentication Lambda CloudWatch log group encryption | `string` | `null` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration, logging is disabled by default. | <pre>object({<br/>    target_bucket = string<br/>    target_prefix = string<br/>    output_format = optional(string, "parquet")<br/>  })</pre> | `null` | no |
 | <a name="input_login_uri_path"></a> [login\_uri\_path](#input\_login\_uri\_path) | Optional path to the login URL | `string` | `null` | no |
 | <a name="input_max_ttl"></a> [max\_ttl](#input\_max\_ttl) | Maximum amount of time (in seconds) that an object is in a CloudFront cache | `number` | `86400` | no |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As opposed to other MCAF modules, this module does not provide a specific resour
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_authentication"></a> [authentication](#module\_authentication) | schubergphilis/mcaf-lambda/aws | ~> 3.0.0 |
-| <a name="module_origin_bucket"></a> [origin\_bucket](#module\_origin\_bucket) | schubergphilis/mcaf-s3/aws | ~> 2.0.0 |
+| <a name="module_origin_bucket"></a> [origin\_bucket](#module\_origin\_bucket) | schubergphilis/mcaf-s3/aws | ~> 3.0.0 |
 
 ## Resources
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,12 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v3.0.0
+
+### Key Changes
+
+- `kms_key_arn` is now used to encrypt all relevant resources: SSM SecureString parameters, the authentication Lambda CloudWatch log group, and the S3 origin bucket.
+
 ## Upgrading to v2.0.0
 
 ### Key Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,7 @@ This document captures required refactoring on your part when upgrading to a mod
 ### Key Changes
 
 - `kms_key_arn` is now used to encrypt all relevant resources: SSM SecureString parameters, the authentication Lambda CloudWatch log group, and the S3 origin bucket.
+- mcaf-s3 bucket upgraded to ~> 3.0.0 
 
 ## Upgrading to v2.0.0
 

--- a/auth.tf
+++ b/auth.tf
@@ -44,13 +44,14 @@ module "authentication" {
   source  = "schubergphilis/mcaf-lambda/aws"
   version = "~> 3.0.0"
 
-  region   = local.global_region
-  name     = "${var.name}-authentication"
-  filename = "${path.module}/auth_lambda/artifacts/index.zip"
-  runtime  = "nodejs22.x"
-  handler  = "index.handler"
-  publish  = true
-  tags     = var.tags
+  region      = local.global_region
+  name        = "${var.name}-authentication"
+  filename    = "${path.module}/auth_lambda/artifacts/index.zip"
+  runtime     = "nodejs22.x"
+  handler     = "index.handler"
+  publish     = true
+  kms_key_arn = var.lambda_kms_key_arn
+  tags        = var.tags
 
   execution_role = {
     create_policy = true

--- a/auth.tf
+++ b/auth.tf
@@ -50,7 +50,7 @@ module "authentication" {
   runtime     = "nodejs22.x"
   handler     = "index.handler"
   publish     = true
-  kms_key_arn = var.lambda_kms_key_arn
+  kms_key_arn = var.kms_key_arn
   tags        = var.tags
 
   execution_role = {

--- a/bucket.tf
+++ b/bucket.tf
@@ -55,6 +55,7 @@ module "origin_bucket" {
   block_public_policy     = var.block_public_policy
   force_destroy           = var.force_destroy
   ignore_public_acls      = var.ignore_public_acls
+  kms_key_arn             = var.bucket_kms_key_arn
   lifecycle_rule          = var.bucket_lifecycle_rule
   restrict_public_buckets = var.restrict_public_buckets
   policy                  = data.aws_iam_policy_document.origin_bucket.json

--- a/bucket.tf
+++ b/bucket.tf
@@ -55,7 +55,7 @@ module "origin_bucket" {
   block_public_policy     = var.block_public_policy
   force_destroy           = var.force_destroy
   ignore_public_acls      = var.ignore_public_acls
-  kms_key_arn             = var.bucket_kms_key_arn
+  kms_key_arn             = var.kms_key_arn
   lifecycle_rule          = var.bucket_lifecycle_rule
   restrict_public_buckets = var.restrict_public_buckets
   policy                  = data.aws_iam_policy_document.origin_bucket.json

--- a/bucket.tf
+++ b/bucket.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "origin_bucket" {
 
 module "origin_bucket" {
   source  = "schubergphilis/mcaf-s3/aws"
-  version = "~> 2.0.0"
+  version = "~> 3.0.0"
 
   region                  = var.region
   name                    = var.name

--- a/variables.tf
+++ b/variables.tf
@@ -212,22 +212,10 @@ variable "ipv6_enabled" {
   description = "Whether IPv6 is enabled for the distribution"
 }
 
-variable "bucket_kms_key_arn" {
-  type        = string
-  default     = null
-  description = "The ARN of the KMS key used for S3 origin bucket encryption"
-}
-
 variable "kms_key_arn" {
   type        = string
   default     = null
-  description = "The ARN of the KMS key used for SSM SecureString parameter encryption"
-}
-
-variable "lambda_kms_key_arn" {
-  type        = string
-  default     = null
-  description = "The ARN of the KMS key used for the authentication Lambda CloudWatch log group encryption"
+  description = "The ARN of the KMS key used for all encryption: SSM SecureString parameters, Lambda CloudWatch log group, and S3 origin bucket"
 }
 
 variable "lambda_function_association" {

--- a/variables.tf
+++ b/variables.tf
@@ -328,7 +328,6 @@ variable "restrict_public_buckets" {
   description = "Whether Amazon S3 should restrict public bucket policies for this bucket"
 }
 
-
 variable "subdomain" {
   type        = string
   description = "A DNS subdomain for this distribution"

--- a/variables.tf
+++ b/variables.tf
@@ -212,10 +212,22 @@ variable "ipv6_enabled" {
   description = "Whether IPv6 is enabled for the distribution"
 }
 
+variable "bucket_kms_key_arn" {
+  type        = string
+  default     = null
+  description = "The ARN of the KMS key used for S3 origin bucket encryption"
+}
+
 variable "kms_key_arn" {
   type        = string
   default     = null
-  description = "The ARN of the KMS key used for encryption"
+  description = "The ARN of the KMS key used for SSM SecureString parameter encryption"
+}
+
+variable "lambda_kms_key_arn" {
+  type        = string
+  default     = null
+  description = "The ARN of the KMS key used for the authentication Lambda CloudWatch log group encryption"
 }
 
 variable "lambda_function_association" {
@@ -315,6 +327,7 @@ variable "restrict_public_buckets" {
   default     = true
   description = "Whether Amazon S3 should restrict public bucket policies for this bucket"
 }
+
 
 variable "subdomain" {
   type        = string


### PR DESCRIPTION
:hammer_and_wrench: Summary

 Use single KMS with kms_key_arn used across SSM SecureString parameters,
 authentication Lambda log group, and S3 origin bucket. 

 :rocket: Motivation

 We want a single-key model for encryption and to simplify configuration.

 :pencil: Additional Information

 This is a breaking change for v3.0.0. Upgrade docs were updated in UPGRADING.md.
 Fix Terraform Docs outputs in README.