### PR TITLE
fix(auth): add kms:Decrypt permission for authentication lambda role …

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -41,6 +41,22 @@ data "aws_iam_policy_document" "authentication" {
       "arn:aws:ssm:*:*:parameter/cloudfront-config/*"
     ]
   }
+
+  dynamic "statement" {
+    for_each = var.kms_key_arn != null ? [var.kms_key_arn] : []
+
+    content {
+      sid       = "AllowKmsDecryptForSsmParameters"
+      actions   = ["kms:Decrypt", "kms:DescribeKey"]
+      resources = [statement.value]
+
+      condition {
+        test     = "StringEquals"
+        variable = "kms:ViaService"
+        values   = ["ssm.${local.global_region}.amazonaws.com"]
+      }
+    }
+  }
 }
 
 module "authentication" {


### PR DESCRIPTION
Adds conditional KMS permissions (kms:Decrypt, kms:DescribeKey) to the authentication Lambda IAM policy when kms_key_arn is provided, fixing AccessDeniedException during SSM GetParameters with decryption.